### PR TITLE
Feature/pickle dict objects in id table

### DIFF
--- a/document/update_apidoc.sh
+++ b/document/update_apidoc.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# when adding new module to maflib, please
+# run this command to add the document of
+# that new module.
+
+sphinx-apidoc -f -o ./source ../maflib

--- a/maflib/core.py
+++ b/maflib/core.py
@@ -476,21 +476,40 @@ class ParameterIdGenerator(object):
         """Path to file that the table is dumped to as a human-readable text."""
 
         if os.path.exists(path):
-            with open(path) as f:
-                self._table = pickle.load(f)
+            self._table = self._load_table(path)
         else:
             self._table = {}
 
     def save(self):
         """Serializes the table to the file at self.path."""
+
+        parameter_ids = [(param, int(id)) for (param, id) in self._table.items()]
+        parameter_ids.sort(key=lambda param_and_id: param_and_id[1])
+        
         with _create_file(self.path) as f:
-            pickle.dump(self._table, f)
+            # We don't save the self._table, which type is dict(Parameter,int) directly,
+            # instead saves list(dict), which index corresponds to the id of the item.
+            # This is for deserializing parameter->id mappings outside of map, without
+            # maflib and waflib dependencies. Parameter class is defined in maflib,
+            # so user cannot decode original _table object without maflib libraries.
+            # When deserializaing, ``self._table`` is load by ``_load_table``.
+            max_param_id = parameter_ids[-1][1]
+            dict_param_list = [None for i in range(max_param_id + 1)]
+            for (param, id) in parameter_ids:
+                dict_param_list[id] = dict(param)
+            pickle.dump(dict_param_list, f)
 
         with _create_file(self.text_path) as f:
-            parameter_ids = self._table.items()
-            parameter_ids.sort(key=lambda param_and_id: int(param_and_id[1]))
             for parameter, id in parameter_ids:
                 f.write('%s\t%s\n' % (id, parameter))
+
+    def _load_table(self, path):
+        table = {}
+        with open(path) as f:
+            dict_param_list = pickle.load(f)
+            for i, dict_param in enumerate(dict_param_list):
+                if dict_param is not None: table[Parameter(dict_param)] = str(i)
+        return table
 
     def get_id(self, parameter):
         """Gets the id of given parameter.


### PR DESCRIPTION
Related to #23. We selected not to serialize json object into .maf_id_table.tsv, but to save object mapping object->ids with pickle, which user can load without maflib dependencies.
The data structure of object in .maf_id_table is changed from dict(Parameter, id) to list(dict), in which dict is converted from Parameter, and index of list is corresponds to the id of that object.
