### PR TITLE
change the load/save methods of maf_id_table

### DIFF
--- a/maflib/core.py
+++ b/maflib/core.py
@@ -476,21 +476,40 @@ class ParameterIdGenerator(object):
         """Path to file that the table is dumped to as a human-readable text."""
 
         if os.path.exists(path):
-            with open(path) as f:
-                self._table = pickle.load(f)
+            self._table = self._load_table(path)
         else:
             self._table = {}
 
     def save(self):
         """Serializes the table to the file at self.path."""
+
+        parameter_ids = [(param, int(id)) for (param, id) in self._table.items()]
+        parameter_ids.sort(key=lambda param_and_id: param_and_id[1])
+        
         with _create_file(self.path) as f:
-            pickle.dump(self._table, f)
+            # We don't save the self._table, which type is dict(Parameter,int) directly,
+            # instead saves list(dict), which index corresponds to the id of the item.
+            # This is for deserializing parameter->id mappings outside of map, without
+            # maflib and waflib dependencies. Parameter class is defined in maflib,
+            # so user cannot decode original _table object without maflib libraries.
+            # When deserializaing, ``self._table`` is load by ``_load_table``.
+            max_param_id = parameter_ids[-1][1]
+            dict_param_list = [None for i in range(max_param_id + 1)]
+            for (param, id) in parameter_ids:
+                dict_param_list[id] = dict(param)
+            pickle.dump(dict_param_list, f)
 
         with _create_file(self.text_path) as f:
-            parameter_ids = self._table.items()
-            parameter_ids.sort(key=lambda param_and_id: int(param_and_id[1]))
             for parameter, id in parameter_ids:
                 f.write('%s\t%s\n' % (id, parameter))
+
+    def _load_table(self, path):
+        table = {}
+        with open(path) as f:
+            dict_param_list = pickle.load(f)
+            for i, dict_param in enumerate(dict_param_list):
+                if dict_param is not None: table[Parameter(dict_param)] = str(i)
+        return table
 
     def get_id(self, parameter):
         """Gets the id of given parameter.

--- a/maflib/core.py
+++ b/maflib/core.py
@@ -483,6 +483,8 @@ class ParameterIdGenerator(object):
     def save(self):
         """Serializes the table to the file at self.path."""
 
+        if len(self._table) == 0: return
+
         parameter_ids = [(param, int(id)) for (param, id) in self._table.items()]
         parameter_ids.sort(key=lambda param_and_id: param_and_id[1])
         

--- a/maflib/core.py
+++ b/maflib/core.py
@@ -505,10 +505,12 @@ class ParameterIdGenerator(object):
 
     def _load_table(self, path):
         table = {}
-        with open(path) as f:
-            dict_param_list = pickle.load(f)
-            for i, dict_param in enumerate(dict_param_list):
-                if dict_param is not None: table[Parameter(dict_param)] = str(i)
+        try:
+            with open(path) as f:
+                dict_param_list = pickle.load(f)
+                for i, dict_param in enumerate(dict_param_list):
+                    if dict_param is not None: table[Parameter(dict_param)] = str(i)
+        except EOFError: pass
         return table
 
     def get_id(self, parameter):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -25,6 +25,7 @@
 
 from maflib.core import *
 import unittest
+import shutil
 
 class TestParameter(unittest.TestCase):
     def test_empty_parameter_does_not_conflict(self):
@@ -77,7 +78,18 @@ class TestParameter(unittest.TestCase):
         self.assertFalse(Parameter(a=2) in d)
         self.assertFalse(Parameter(a=1, b=2, c=3) in d)
 
-        
+
+class Setting(object):
+    def __init__(self, a, b, c):
+        self.a = a
+        self.b = b
+        self.c = c
+    def __eq__(self, other):
+        return (isinstance(other, self.__class__)
+            and self.__dict__ == other.__dict__)
+    def __ne__(self, other): return not self.__eq__(other)
+
+    
 class TestParameterIdGenerator(unittest.TestCase):
     def test_decode_pickled_parameter_with_object(self):
         # TODO(noji): change to use tempfile for generating pickle_path after revise_create_file is merged
@@ -87,9 +99,15 @@ class TestParameterIdGenerator(unittest.TestCase):
         # text_path.close()
         # pickle_path = pickle_path.name
         # text_path = text_path.name
-        pickle_path = ".maf_tmp_dir/tmp_parameters.pickle"
-        text_path = ".maf_tmp_dir/tmp_parameters.txt"
+
+        def clean_environment():
+            if os.path.exists(".maf_tmp_dir"): shutil.rmtree(".maf_tmp_dir")
+
+        clean_environment()
         try:
+            pickle_path = ".maf_tmp_dir/tmp_parameters.pickle"
+            text_path = ".maf_tmp_dir/tmp_parameters.txt"
+
             id_generator = ParameterIdGenerator(pickle_path, text_path)
 
             id_generator.get_id(Parameter({"setting": Setting(0,1,2)}))
@@ -100,7 +118,7 @@ class TestParameterIdGenerator(unittest.TestCase):
             self.assertEqual(1, len(table))
             self.assertEqual({"setting":Setting(0,1,2)}, table[0])
         finally:
-            shutil.rmtree(".maf_tmp_dir")
+            clean_environment()
 
             
 class TestCallObject(unittest.TestCase):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -77,7 +77,32 @@ class TestParameter(unittest.TestCase):
         self.assertFalse(Parameter(a=2) in d)
         self.assertFalse(Parameter(a=1, b=2, c=3) in d)
 
+        
+class TestParameterIdGenerator(unittest.TestCase):
+    def test_decode_pickled_parameter_with_object(self):
+        # TODO(noji): change to use tempfile for generating pickle_path after revise_create_file is merged
+        # pickle_path = tempfile.NamedTemporaryFile()
+        # text_path = tempfile.NamedTemporaryFile()
+        # pickle_path.close()
+        # text_path.close()
+        # pickle_path = pickle_path.name
+        # text_path = text_path.name
+        pickle_path = ".maf_tmp_dir/tmp_parameters.pickle"
+        text_path = ".maf_tmp_dir/tmp_parameters.txt"
+        try:
+            id_generator = ParameterIdGenerator(pickle_path, text_path)
 
+            id_generator.get_id(Parameter({"setting": Setting(0,1,2)}))
+            id_generator.save()
+        
+            table = pickle.load(open(pickle_path))
+        
+            self.assertEqual(1, len(table))
+            self.assertEqual({"setting":Setting(0,1,2)}, table[0])
+        finally:
+            shutil.rmtree(".maf_tmp_dir")
+
+            
 class TestCallObject(unittest.TestCase):
     def test_listize_source(self):
         self._test_listize('source')


### PR DESCRIPTION
Related to #23. We selected not to serialize json object into .maf_id_table.tsv, but to save object mapping object->ids with pickle, which user can load without maflib dependencies.
The data structure of object in .maf_id_table is changed from dict(Parameter, id) to list(dict), in which dict is converted from Parameter, and index of list is corresponds to the id of that object.
