### PR TITLE
Support tasks of directory inputs/outputs

### DIFF
--- a/maflib/core.py
+++ b/maflib/core.py
@@ -621,7 +621,7 @@ class ExperimentTask(waflib.Task.Task):
                         try:
                             v = v.get_bld_sig()
                         except AttributeError:
-                            raise Errors.WafError('Missing node signature for %r (required by %r)' % (v, self))
+                            raise waflib.Errors.WafError('Missing node signature for %r (required by %r)' % (v, self))
                     elif hasattr(v, '__call__'):
                         v = v() # dependency is a function, call it
                     upd(v)

--- a/maflib/core.py
+++ b/maflib/core.py
@@ -275,7 +275,7 @@ class ExperimentContext(waflib.Build.BuildContext):
         # To avoid this problem, we first run search_node to find directory meta
         # node. If this is failed, normal search with find_or_declare will be run.
         existing_dir_node = self.path.get_bld().search_node(node)
-        if (existing_dir_node):
+        if existing_dir_node:
             return existing_dir_node
         else:
             return self.path.find_or_declare(node)

--- a/maflib/core.py
+++ b/maflib/core.py
@@ -261,13 +261,19 @@ class ExperimentContext(waflib.Build.BuildContext):
             node = os.path.join(
                 node, '-'.join([parameter_id, os.path.basename(node)]))
         if node[0] == '/':
-            return self.root.find_node(node) # this can find directories (compared to find_resource, which can only find files)
+            # find_node can find directories (compared to find_resource, which can only find files)
+            return self.root.find_node(node) 
 
-        # Currently, the below contains some tricks for supporting directory metanodes;
-        # Suppose node represent a metanode that is a directory on the filesystem.
-        # When we search this node by ``find_or_declare``, we can get that node object, but ``find_or_declare`` overwrites the sig property of found node with None. This sig property will be used when deciding whether run or not current task, and if sig is set None, the task is always run.
-        # see: http://docs.waf.googlecode.com/git/apidocs_17/_modules/waflib/Node.html#Node.find_or_declare
-        # To avoid this problem, we first run search_node to find directory meta node. If this is failed, normal search with find_or_declare will be run.
+        # Currently, the below contains some tricks for supporting directory
+        # metanodes; Suppose node represent a metanode that is a directory on
+        # the filesystem. When we search this node by ``find_or_declare``, we
+        # can get that node object, but ``find_or_declare`` overwrites the sig
+        # property of found node with None. This sig property will be used when
+        # deciding whether run or not current task, and if sig is set None,
+        # the task is always run. See:
+        # http://docs.waf.googlecode.com/git/apidocs_17/_modules/waflib/Node.html#Node.find_or_declare
+        # To avoid this problem, we first run search_node to find directory meta
+        # node. If this is failed, normal search with find_or_declare will be run.
         existing_dir_node = self.path.get_bld().search_node(node)
         if (existing_dir_node):
             return existing_dir_node

--- a/maflib/core.py
+++ b/maflib/core.py
@@ -621,6 +621,7 @@ class ExperimentTask(waflib.Task.Task):
                         try:
                             v = v.get_bld_sig()
                         except AttributeError:
+                            import waflib.Errors
                             raise waflib.Errors.WafError('Missing node signature for %r (required by %r)' % (v, self))
                     elif hasattr(v, '__call__'):
                         v = v() # dependency is a function, call it


### PR DESCRIPTION
See #37.

User have to call `mkdir()` of the node when one want to use that node as the directory.
We might have to add new example to use this mechanism or write document.
