### PR TITLE
Integrate build and experiment commands.

### DIFF
--- a/maflib/core.py
+++ b/maflib/core.py
@@ -69,8 +69,13 @@ class ExperimentContext(waflib.Build.BuildContext):
     def __call__(self, **kw):
         """Main method to generate tasks."""
 
-        call_object = CallObject(wscript=self.cur_script, **kw)
-        self._experiment_graph.add_call_object(call_object)
+        if 'rule' not in kw:
+            # Workaround for non-experimental tasks
+            # TODO(beam2d): Integrate non-/experimental tasks
+            super(ExperimentContext, self).__call__(**kw)
+        else:
+            call_object = CallObject(wscript=self.cur_script, **kw)
+            self._experiment_graph.add_call_object(call_object)
 
     def _process_call_objects(self):
         """Callback function called right after all wscripts are executed.

--- a/maflib/core.py
+++ b/maflib/core.py
@@ -57,10 +57,6 @@ def configure(conf):
 class ExperimentContext(waflib.Build.BuildContext):
     """Context class of waf experiment (a.k.a. maf)."""
 
-    cmd = 'experiment'
-    fun = 'experiment'
-    variant = 'experiment'
-
     def __init__(self, **kw):
         super(ExperimentContext, self).__init__(**kw)
         self._experiment_graph = ExperimentGraph()
@@ -689,6 +685,20 @@ class ExperimentNode(object):
 
     def abspath(self):
         return self.abspath_
+
+
+# Forces these commands run under ExperimentContext
+waflib.Build.CleanContext.__bases__ = (ExperimentContext,)
+waflib.Build.InstallContext.__bases__ = (ExperimentContext,)
+waflib.Build.ListContext.__bases__ = (ExperimentContext,)
+waflib.Build.StepContext.__bases__ = (ExperimentContext,)
+waflib.Build.UninstallContext.__bases__ = (ExperimentContext,)
+
+
+# Old command experiment
+class OldExperimentContext(ExperimentContext):
+    cmd = 'experiment'
+    fun = 'experiment'
 
 
 @feature('experiment')


### PR DESCRIPTION
This change makes the `build` command run as the current `experiment` command, and makes other related commands (`list`, `clean` etc) run under ExperimentContext.
It adds following changes on the behavior of maf:
- Now user can implement experiments in `build()` function
- User can run such experiment just by `./waf`
- Old `experiment` command and function are still supported
- Results are put under `build/` directory instead of `build/experiment`
- Related commands such as `list` and `clean` are now correctly running for maf
