### PR TITLE
Feature/fix bug in save id table tsv

### DIFF
--- a/maflib/core.py
+++ b/maflib/core.py
@@ -732,7 +732,7 @@ class ParameterIdGenerator(object):
             pickle.dump(dicted_params, f)
 
         with _create_file(self.text_path) as f:
-            for i, parameter in enumerate(self._parameters):
+            for id, parameter in enumerate(self._parameters):
                 f.write('%s\t%s\n' % (id, parameter))
 
     def _load_table(self, path):


### PR DESCRIPTION
With a bug, an output of ".maf_id_table.tsv" looked like:

```
<built-in function id>  {'C': 0.001, 'B': -1, 's': 0}
<built-in function id>  {'C': 0.001, 'B': -1, 's': 1}
<built-in function id>  {'C': 0.01, 'B': -1, 's': 0}
<built-in function id>  {'C': 0.01, 'B': -1, 's': 1}
```

I fixed it to output id numbers.
