### PR TITLE
Return early _generate_tasks if no source is given

### DIFF
--- a/maflib/core.py
+++ b/maflib/core.py
@@ -131,6 +131,7 @@ class ExperimentContext(waflib.Build.BuildContext):
         if not call_object.rel_source:
             for parameter in call_object.parameters:
                 self._generate_task(call_object, [], parameter)
+            return
 
         parameter_lists = []
 


### PR DESCRIPTION
Maybe we can insert this return safely
