### PR TITLE
Output maf version number with "--mafversion"

### DIFF
--- a/generate_maf.py
+++ b/generate_maf.py
@@ -28,6 +28,8 @@
 
 import os
 import tarfile
+import re
+import subprocess
 
 TEMPLATE_FILE_NAME = 'maf_template.py'
 TARGET_FILE_NAME = 'maf.py'
@@ -40,6 +42,19 @@ CARRIAGE_RETURN = '#YYY'.encode()
 ARCHIVE_BEGIN = '#==>\n#'.encode()
 ARCHIVE_END = '#<==\n#'.encode()
 
+def compute_maf_revision():
+    p = subprocess.Popen("git log | grep '^commit' | head -1",
+                         shell = 'True',
+                         stdout = subprocess.PIPE,
+                         stderr = subprocess.PIPE)
+    out, err = p.communicate()
+
+    if err:
+        return 'xxx'
+    if out.endswith('\n'):
+        out = out[:-1]
+    return out[7:]
+
 if __name__ == '__main__':
     try:
         archive = tarfile.open(ARCHIVE_FILE_NAME, 'w:bz2')
@@ -51,6 +66,10 @@ if __name__ == '__main__':
    
     with open(TEMPLATE_FILE_NAME) as f:
         code = f.read()
+
+    REVISION = compute_maf_revision()
+    reg = re.compile('^REVISION = (.*)', re.M)
+    code = reg.sub(r"REVISION = '%s'" % REVISION, code)
 
     with open(ARCHIVE_FILE_NAME, 'rb') as f:
         archive = f.read()

--- a/maf_template.py
+++ b/maf_template.py
@@ -147,8 +147,13 @@ def check_mafversion():
     # complicated to track version numbers during development, so we skip
     # version checks during development, which is judged by loaded version
     # number from maflib is not filled.
-    version_from_maflib = maflib.core.MAFVERSION
-    revision_from_maflib = maflib.core.MAFREVISION
+
+    try:
+        version_from_maflib = maflib.core.MAFVERSION
+        revision_from_maflib = maflib.core.MAFREVISION
+    except AttributeError:
+        return # arrive here only with older version
+        
     if version_from_maflib == EMPTY_VERSION or revision_from_maflib == EMPTY_VERSION:
         return
     

--- a/maf_template.py
+++ b/maf_template.py
@@ -42,6 +42,9 @@ import tarfile
 import waflib.Context
 import waflib.Logs
 
+VERSION = '0.2' # This value should be updated when releasing new version (?)
+REVISION = 'x'
+
 TAR_NAME = 'maflib.tar'
 NEW_LINE = '#XXX'.encode()
 CARRIAGE_RETURN = '#YYY'.encode()

--- a/maf_template.py
+++ b/maf_template.py
@@ -42,8 +42,8 @@ import tarfile
 import waflib.Context
 import waflib.Logs
 
-VERSION = '0.2' # This value should be updated when releasing new version (?)
-REVISION = 'x'
+MAFVERSION = 'x'
+MAFREVISION = 'x'
 
 TAR_NAME = 'maflib.tar'
 NEW_LINE = '#XXX'.encode()
@@ -139,3 +139,12 @@ def find_maflib():
 
 find_maflib()
 import maflib.core
+
+if MAFVERSION != maflib.core.MAFVERSION:
+    waflib.Logs.error('Maf script %r and library %r do not match (directory %r)'%
+                      (MAFVERSION, maflib.core.MAFVERSION, find_maflib()))
+    sys.exit(1)
+
+if MAFREVISION != maflib.core.MAFREVISION:
+    waflib.Logs.warn('Revision of maf script %r and library %r do not match (directory %r)'%
+                     (MAFREVISION, maflib.core.MAFREVISION, find_maflib()))

--- a/maf_template.py
+++ b/maf_template.py
@@ -157,7 +157,7 @@ def check_mafversion():
                           (MAFVERSION, maflib.core.MAFVERSION, find_maflib()))
         sys.exit(1)
 
-    if MAFREVISION != version_from_maflib:
+    if MAFREVISION != revision_from_maflib:
         waflib.Logs.warn('Revision of maf script %r and library %r do not match (directory %r)'%
                          (MAFREVISION, maflib.core.MAFREVISION, find_maflib()))
 

--- a/maf_template.py
+++ b/maf_template.py
@@ -148,23 +148,29 @@ def check_mafversion():
     # version checks during development, which is judged by loaded version
     # number from maflib is not filled.
 
+    maflib_path = find_maflib()
+    instruction = 'Please update local maflib by "rm -r %s && ./waf configure"' % \
+                  (maflib_path)
     try:
         version_from_maflib = maflib.core.MAFVERSION
         revision_from_maflib = maflib.core.MAFREVISION
     except AttributeError:
-        return # arrive here only with older version
+        waflib.Logs.error('Loaded library version is old (<= 0.2); ' + instruction)
+        sys.exit(1)
         
     if version_from_maflib == EMPTY_VERSION or revision_from_maflib == EMPTY_VERSION:
         return
     
     if MAFVERSION != version_from_maflib:
-        waflib.Logs.error('Maf script %r and library %r do not match (directory %r)'%
-                          (MAFVERSION, maflib.core.MAFVERSION, find_maflib()))
+        waflib.Logs.error('Maf script %r and library %r do not match (directory %r); '%
+                          (MAFVERSION, maflib.core.MAFVERSION, maflib_path) +
+                          instruction)
         sys.exit(1)
 
     if MAFREVISION != revision_from_maflib:
-        waflib.Logs.warn('Revision of maf script %r and library %r do not match (directory %r)'%
-                         (MAFREVISION, maflib.core.MAFREVISION, find_maflib()))
+        waflib.Logs.warn('Revision of maf script %r and library %r do not match (directory %r); '%
+                         (MAFREVISION, maflib.core.MAFREVISION, maflib_path) +
+                         instruction)
 
 find_maflib()
 import maflib.core

--- a/maflib/core.py
+++ b/maflib/core.py
@@ -573,8 +573,12 @@ class ExpOptionsContext(waflib.Options.OptionsContext):
                       help = 'path to the output of graph [default: %s]' % default_path)
         gr.add_option('--simple_param', action = 'store_true', default = False,
                       help = 'outputs parameter ids instead of specific values')
-        
-        
+
+        # TODO: get the maf revision number here
+        self.version = 'unimplemented yet'
+        self.add_option('--mafversion', action = 'version',
+                        help = 'show the currently used maf version and exit')
+
 class CyclicDependencyException(Exception):
     """Exception raised when experiment graph has a cycle."""
     pass

--- a/maflib/core.py
+++ b/maflib/core.py
@@ -576,8 +576,7 @@ class ExpOptionsContext(waflib.Options.OptionsContext):
         gr.add_option('--simple_param', action = 'store_true', default = False,
                       help = 'outputs parameter ids instead of specific values')
 
-        # TODO: get the maf revision number here
-        self.version = 'unimplemented yet'
+        self.parser.version = 'maf %s (%s)' % (MAFVERSION, MAFREVISION)
         self.add_option('--mafversion', action = 'version',
                         help = 'show the currently used maf version and exit')
 

--- a/maflib/core.py
+++ b/maflib/core.py
@@ -49,6 +49,8 @@ import waflib.Utils
 import waflib.Options
 from waflib.TaskGen import before_method, feature
 
+MAFVERSION = 'x'
+MAFREVISION = 'x'
 
 def options(opt):
     pass

--- a/samples/liblinear/wscript
+++ b/samples/liblinear/wscript
@@ -51,7 +51,8 @@ def build(exp):
         target='model',
         parameters=maflib.util.product({
             's': [0, 1, 2, 3, 4, 5, 6, 7],  # method
-            'C': [0.001, 0.01, 0.1, 1, 10, 100],  # regularization parameter
+            # 'C': [0.001, 0.01, 0.1, 1, 10, 100],  # regularization parameter
+            'C': [0.001, 0.01],  # regularization parameter
             'B': [1, -1]  # use bias or not
         }),
         rule='liblinear-train -s ${s} -c ${C} -B ${B} ${SRC} ${TGT} > /dev/null')

--- a/samples/liblinear/wscript
+++ b/samples/liblinear/wscript
@@ -51,8 +51,7 @@ def build(exp):
         target='model',
         parameters=maflib.util.product({
             's': [0, 1, 2, 3, 4, 5, 6, 7],  # method
-            # 'C': [0.001, 0.01, 0.1, 1, 10, 100],  # regularization parameter
-            'C': [0.001, 0.01],  # regularization parameter
+            'C': [0.001, 0.01, 0.1, 1, 10, 100],  # regularization parameter
             'B': [1, -1]  # use bias or not
         }),
         rule='liblinear-train -s ${s} -c ${C} -B ${B} ${SRC} ${TGT} > /dev/null')


### PR DESCRIPTION
Incomplete implementation for #89.

Currently maf.py obtain the revision number of git, but now maflib cannot access to it.
We have to implement core.ExpOptionsContext.**init**. The version is now a constant of in maf.py, but we cannot access this number from maflib. Maybe we have to make an auto generated file in .waf-*/maflib directory to save some constants.
