### PR TITLE
All prepared rules are wrapped with util.rule

### DIFF
--- a/samples/liblinear/wscript
+++ b/samples/liblinear/wscript
@@ -42,9 +42,10 @@ def build(exp):
     website = 'http://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/multiclass/'
 
     exp(target='news20.scale',
-        rule=maflib.rules.download(website+'/news20.scale.bz2', 'bz2'))
+        rule=maflib.rules.download(url=website+'/news20.scale.bz2', decompress_as='bz2'))
+    
     exp(target='news20.t.scale',
-        rule=maflib.rules.download(website+'/news20.t.scale.bz2', 'bz2'))
+        rule=maflib.rules.download(url=website+'/news20.t.scale.bz2', decompress_as='bz2'))
 
     # Train with various parameters.
     exp(source='news20.scale',
@@ -71,7 +72,7 @@ def build(exp):
     exp(source='result',
         target='max_accuracy',
         aggregate_by='B',
-        rule=maflib.rules.max('accuracy'))
+        rule=maflib.rules.max(key='accuracy'))
 
     # Plot a line chart.
     exp(source='max_accuracy',

--- a/samples/vowpal/wscript
+++ b/samples/vowpal/wscript
@@ -61,13 +61,13 @@ def build(exp):
     website = 'http://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/multiclass/'
 
     exp(target='news20.scale',
-        rule=maflib.rules.download('%s/news20.scale.bz2' % website, 'bz2'))
+        rule=maflib.rules.download(url='%s/news20.scale.bz2' % website, decompress_as='bz2'))
     exp(source='news20.scale',
         target='news20.scale.vw',
         rule=convert_libsvm_format_to_vowpal)
 
     exp(target='news20.t.scale',
-        rule=maflib.rules.download('%s/news20.t.scale.bz2' % website, 'bz2'))
+        rule=maflib.rules.download(url='%s/news20.t.scale.bz2' % website, decompress_as='bz2'))
     exp(source='news20.t.scale',
         target='news20.t.scale.vw',
         rule=convert_libsvm_format_to_vowpal)

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -19,7 +19,7 @@ class TestAggregationTask(unittest.TestCase):
         task.set_input_by_json(0, {"key1":10, "key2":20})
         task.set_input_by_json(1, {"key1": 5, "key2":30})
 
-        rule = rules.max("key1")
+        rule = rules.max(key="key1")
         rule.fun(task)
 
         result = task.json_output(0)
@@ -32,7 +32,7 @@ class TestAggregationTask(unittest.TestCase):
         task.set_input_by_json(0, {"key1":10, "key2":20})
         task.set_input_by_json(1, {"key1": 5, "key2":30})
 
-        rule = rules.min("key1")
+        rule = rules.min(key="key1")
         rule.fun(task)
 
         result = task.json_output(0)
@@ -78,7 +78,7 @@ class TestSegmentLibsvm(unittest.TestCase):
         task.set_input(0, '\n'.join([' '.join([str(e) for e in line]) for line in data]) + '\n')
         task.outputs.setsize(3)
         
-        rule = rules.segment_without_label_bias(self.weights)
+        rule = rules.segment_without_label_bias(weights=self.weights)
         rule.fun(task)
         return task
     


### PR DESCRIPTION
- All rules are decollated with `util.rule`
- All wrapped rules, which receive some parameters, such as `download` or `max` are now not wrapped and parameters are specified by task parameters. The current problem is it cannot be failed when the required parameter is not given (see #109).
